### PR TITLE
Fix bug when styles are definied inside a defs-tag. 

### DIFF
--- a/src/Svg/Document.php
+++ b/src/Svg/Document.php
@@ -396,8 +396,14 @@ class Document extends AbstractTag
                 break;
         }
 
-        if (!$this->inDefs && $tag) {
+        if (!$tag) {
+            return;
+        }
+
+        if(!$this->inDefs) {
             $tag->handleEnd();
+        } else {
+            $tag->handleInDefEnd();
         }
     }
-} 
+}

--- a/src/Svg/Tag/AbstractTag.php
+++ b/src/Svg/Tag/AbstractTag.php
@@ -72,6 +72,10 @@ abstract class AbstractTag
         }
     }
 
+    public function handleInDefEnd()
+    {
+    }
+
     protected function before($attributes)
     {
     }
@@ -180,4 +184,4 @@ abstract class AbstractTag
             }
         }
     }
-} 
+}

--- a/src/Svg/Tag/StyleTag.php
+++ b/src/Svg/Tag/StyleTag.php
@@ -14,6 +14,14 @@ class StyleTag extends AbstractTag
 {
     protected $text = "";
 
+    public function handleInDefEnd()
+    {
+        if ($this->getDocument()->inDefs) {
+            $this->end();
+            $this->after();
+        }
+    }
+
     public function end()
     {
         $parser = new CSS\Parser($this->text);
@@ -24,4 +32,4 @@ class StyleTag extends AbstractTag
     {
         $this->text .= $text;
     }
-} 
+}


### PR DESCRIPTION
In this case the styles were not applied because the stylesheet was not appended to the document. (Happened on a SVG-document exported via Illustrator 21.1.0)